### PR TITLE
Remove preview version to use .NET Core 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _Note - If we were to use a sidecar, we would need to define `containerName` whi
 
 - Azure CLI
 - Azure Subscription
-- .NET Core 3.0 Preview 5
+- .NET Core 3.0
 - Kubernetes cluster with [KEDA installed](https://github.com/kedacore/keda#setup)
 
 ## Setup

--- a/src/Keda.Samples.Dotnet.OrderProcessor/Dockerfile
+++ b/src/Keda.Samples.Dotnet.OrderProcessor/Dockerfile
@@ -1,7 +1,7 @@
-FROM mcr.microsoft.com/dotnet/core/runtime:3.0.0-preview5-alpine AS base
+FROM mcr.microsoft.com/dotnet/core/runtime:3.0.0-alpine AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100-preview5-alpine AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100-alpine AS build
 WORKDIR /src
 COPY ["Keda.Samples.Dotnet.OrderProcessor/Keda.Samples.Dotnet.OrderProcessor.csproj", "Keda.Samples.Dotnet.OrderProcessor/"]
 COPY ["Keda.Samples.Dotnet.Contracts/Keda.Samples.Dotnet.Contracts.csproj", "Keda.Samples.Dotnet.Contracts/"]

--- a/src/Keda.Samples.Dotnet.OrderProcessor/Keda.Samples.Dotnet.OrderProcessor.csproj
+++ b/src/Keda.Samples.Dotnet.OrderProcessor/Keda.Samples.Dotnet.OrderProcessor.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0-preview5.19227.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.7.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>


### PR DESCRIPTION
Remove preview version to use .NET Core 3.0.0.

New Docker image is available on https://hub.docker.com/r/tomkerkhove/keda-sample-dotnet-worker-servicebus-queue.